### PR TITLE
Compatibility: run tests on Windows

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -6,6 +6,8 @@ Basic unittest for graph
 """
 
 import unittest
+import tempfile
+import os
 
 from catcli.catcli import *
 from catcli.noder import Noder
@@ -19,7 +21,7 @@ class TestGraph(unittest.TestCase):
     def test_graph(self):
         # init
         path = 'fake'
-        gpath = '/tmp/graph.dot'
+        gpath = tempfile.gettempdir() + os.sep + 'graph.dot'
         self.addCleanup(clean, path)
         self.addCleanup(clean, gpath)
         catalog = Catalog(path, force=True, verbose=False)


### PR DESCRIPTION
I cloned the repo on a windows machine and tried to run `test.sh` (with the bash compatible shell provided by Git).

First I had to work through a few error messages related to the environment, with these solutions:

```
pip install pycodestyle
ln /c/Python37/python.exe /c/Python37/python3.exe
pip3 install nose
```
Then I encountered an error inside the tests:

```
======================================================================
ERROR: test_graph (tests.test_graph.TestGraph)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Users\Your Ass\code\catcli\tests\test_graph.py", line 33, in test_graph
    cmd_graph(args, noder, top)
  File "C:\Users\Your Ass\code\catcli\catcli\catcli.py", line 163, in cmd_graph
    cmd = noder.to_dot(top, path)
  File "C:\Users\Your Ass\code\catcli\catcli\noder.py", line 260, in to_dot
    anytree.exporter.DotExporter(node).to_dotfile(path)
  File "C:\Python37\lib\site-packages\anytree\exporter\dotexporter.py", line 211, in to_dotfile
    with codecs.open(filename, "w", "utf-8") as file:
  File "C:\Python37\lib\codecs.py", line 898, in open
    file = builtins.open(filename, mode, buffering)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/graph.dot'

----------------------------------------------------------------------
Ran 7 tests in 0.150s

FAILED (errors=1)

```

There is no `/tmp/` on windows. Workaround: create `c:\tmp`.

However I modified the code to be platform independent in this commit.

I also tested it on Debian to make sure that nothing broke.