### PR TITLE
Add --raw-size (-s) option to print raw size

### DIFF
--- a/catcli/catcli.py
+++ b/catcli/catcli.py
@@ -36,9 +36,9 @@ USAGE = """
 {0}
 
 Usage:
-    {1} ls     [--catalog=<path>] [--format=<fmt>] [-aBCrVS] [<path>]
-    {1} find   [--catalog=<path>] [--format=<fmt>] [-aBCbdVP] [--path=<path>] <term>
-    {1} tree   [--catalog=<path>] [--format=<fmt>] [-aBCVSH] [<path>]
+    {1} ls     [--catalog=<path>] [--format=<fmt>] [-aBCrVSs] [<path>]
+    {1} find   [--catalog=<path>] [--format=<fmt>] [-aBCbdVsP] [--path=<path>] <term>
+    {1} tree   [--catalog=<path>] [--format=<fmt>] [-aBCVSsH] [<path>]
     {1} index  [--catalog=<path>] [--meta=<meta>...] [-aBCcfnV] <name> <path>
     {1} update [--catalog=<path>] [-aBCcfnV] [--lpath=<path>] <name> <path>
     {1} rm     [--catalog=<path>] [-BCfV] <storage>
@@ -67,6 +67,7 @@ Options:
     -P --parent         Ignore stored relpath [default: True].
     -p --path=<path>    Start path.
     -r --recursive      Recursive [default: False].
+    -s --raw-size       Print raw size rather than human readable [default: False].
     -S --sortsize       Sort by size, largest first [default: False].
     -V --verbose        Be verbose [default: False].
     -v --version        Show version.
@@ -148,7 +149,8 @@ def cmd_ls(args, noder, top):
         path += WILD
     found = noder.walk(top, path,
                        rec=args['--recursive'],
-                       fmt=args['--format'])
+                       fmt=args['--format'],
+                       raw=args['--raw-size'])
     if not found:
         Logger.err('\"{}\": nothing found'.format(args['<path>']))
     return found
@@ -171,15 +173,17 @@ def cmd_find(args, noder, top):
     directory = args['--directory']
     startpath = args['--path']
     fmt = args['--format']
+    raw = args['--raw-size']
     return noder.find_name(top, args['<term>'], script=args['--script'],
                            startpath=startpath, directory=directory,
-                           parentfromtree=fromtree, fmt=fmt)
+                           parentfromtree=fromtree, fmt=fmt, raw=raw)
 
 
 def cmd_tree(args, noder, top):
     path = args['<path>']
     fmt = args['--format']
     hdr = args['--header']
+    raw = args['--raw-size']
 
     # find node to start with
     node = top
@@ -188,7 +192,7 @@ def cmd_tree(args, noder, top):
 
     if node:
         # print the tree
-        noder.print_tree(node, fmt=fmt, header=hdr)
+        noder.print_tree(node, fmt=fmt, header=hdr, raw=raw)
 
 
 def cmd_graph(args, noder, top):

--- a/catcli/utils.py
+++ b/catcli/utils.py
@@ -37,11 +37,11 @@ def md5sum(path):
     return None
 
 
-def human(size):
-    '''human readable size'''
+def size_to_str(size, raw=True):
+    '''convert size to string, optionally human readable'''
     div = 1024.
     suf = ['B', 'K', 'M', 'G', 'T', 'P']
-    if size < div:
+    if raw or size < div:
         return '{}'.format(size)
     for i in suf:
         if size < div:

--- a/tests/test_find.py
+++ b/tests/test_find.py
@@ -25,7 +25,7 @@ class TestFind(unittest.TestCase):
         args = {'<term>': '7544G', '--script': True,
                 '--verbose': True, '--parent': False,
                 '--directory': False, '--path': None,
-                '--format': 'native'}
+                '--format': 'native', '--raw-size': False}
 
         # try to find something
         found = cmd_find(args, noder, top)

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -26,7 +26,8 @@ class TestWalking(unittest.TestCase):
         # create fake args
         args = {'<path>': '', '--recursive': False,
                 '--verbose': True,
-                '--format': 'native'}
+                '--format': 'native',
+                '--raw-size': False}
 
         # list root
         args['<path>'] = ''

--- a/tests/test_rm.py
+++ b/tests/test_rm.py
@@ -26,7 +26,8 @@ class TestRm(unittest.TestCase):
         # create fake args dict
         args = {'<path>': '', '--recursive': False,
                 '--verbose': True,
-                '--format': 'native'}
+                '--format': 'native',
+                '--raw-size': False}
 
         # list files and make sure there are children
         args['<path>'] = ''

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -29,6 +29,7 @@ class TestTree(unittest.TestCase):
             '--verbose': True,
             '--format': 'native',
             '--header': False,
+            '--raw-size': False,
         }
 
         # print tree and wait for any errors


### PR DESCRIPTION
When used the raw size in bytes will be printed, rather than a
summary in human readable form.

This would be really helpful for me to be able to do arithmetic in other tools after importing the output from catcli.

Thanks!