### PR TITLE
Add option to override default catalog path

### DIFF
--- a/catcli/catcli.py
+++ b/catcli/catcli.py
@@ -30,7 +30,7 @@ from catcli.exceptions import BadFormatException, CatcliException
 
 NAME = 'catcli'
 CUR = os.path.dirname(os.path.abspath(__file__))
-CATALOGPATH = f'{NAME}.catalog'
+CATALOGPATH = os.getenv('CATCLI_CATALOG_PATH', f'{NAME}.catalog')
 GRAPHPATH = f'/tmp/{NAME}.dot'
 FORMATS = ['native', 'csv', 'csv-with-header', 'fzf-native', 'fzf-csv']
 


### PR DESCRIPTION
It would be nice to have an option to override the default catalog path using the env variable.
```
$ export CATCLI_CATALOG_PATH=/tmp/catcli.catalog
$ catcli -h | grep "Path to the catalog"
    --catalog=<path>    Path to the catalog [default: /tmp/catcli.catalog].
```